### PR TITLE
Fix brew.sh cask syntax, add untracked casks, and Android SDK setup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,16 @@
       "Bash(gh pr:*)",
       "Bash(git status:*)",
       "Bash(git add:*)",
-      "Bash(git check-ignore:*)"
+      "Bash(git check-ignore:*)",
+      "Bash(claude:*)",
+      "Read(//Users/stevengall/.claude/**)",
+      "Bash(find ~/.claude/plugins -name *.json -o -name *.md)",
+      "Bash(CLAUDE_PLUGIN_ROOT=~/.claude/plugins/cache/claude-plugins-official/learning-output-style/unknown bash ~/.claude/plugins/cache/claude-plugins-official/learning-output-style/unknown/hooks-handlers/session-start.sh)",
+      "Bash(echo \"EXIT: $?\")",
+      "Bash(CLAUDE_PLUGIN_ROOT=~/.claude/plugins/cache/claude-plugins-official/explanatory-output-style/unknown bash ~/.claude/plugins/cache/claude-plugins-official/explanatory-output-style/unknown/hooks-handlers/session-start.sh)",
+      "Bash(CLAUDE_PLUGIN_ROOT=~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.6 bash ~/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.6/hooks/run-hook.cmd session-start)",
+      "Bash(brew list:*)",
+      "Bash(grep -E '^\\(1password|google-chrome|firefox|slack|zoom|oh-my-zsh\\)$')"
     ]
   },
   "hooks": {

--- a/.exports
+++ b/.exports
@@ -33,6 +33,10 @@ export GPG_TTY=$(tty);
 export EDITOR='vim'
 export VISUAL='vim'
 
+# Android SDK
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+
 # Better ls colors
 export LSCOLORS="ExGxBxDxCxEgEdxbxgxcxd"
 export CLICOLOR=1

--- a/.path
+++ b/.path
@@ -3,5 +3,8 @@ export PATH="/usr/local/bin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="$HOME/bin:$PATH"
 
+# Android SDK
+export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
+
 # Volta
 export PATH="$HOME/.volta/bin:$PATH"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ Packages in `brew.sh` are grouped by category. When adding packages, place them 
 14. Browsers
 15. Chat tools
 16. Productivity tools
+17. Hardware / Streaming tools
+18. Fonts
 
 Each package gets a `#comment` above its `brew install` line.
 

--- a/brew.sh
+++ b/brew.sh
@@ -95,6 +95,8 @@ brew install watch
 brew install awscli
 #GitHub CLI
 brew install gh
+#Sourcetree - Git GUI by Atlassian
+brew install --cask sourcetree
 
 #infrastructure tools
 brew install terraform 
@@ -131,25 +133,15 @@ brew install postgresql
 
 
 #Install mac windows management tools
-brew install rectangle
+brew install --cask rectangle
 
 #IDEs
 #VSCode
-brew install visual-studio-code
-#VSCode CLI
-brew install code-cli
-#Cursor
-brew install cursor
-#Cursor CLI
-brew install cursor-cli
+brew install --cask visual-studio-code
 #intellij idea
-brew install intellij-idea
-#intellij idea cli
-brew install intellij-idea-cli
+brew install --cask intellij-idea
 #datagrip
-brew install datagrip
-#datagrip cli
-brew install datagrip-cli
+brew install --cask datagrip
 
 #Python Node and Java Version Managers
 #(Python Version Manager): Similar to nvm for Python. Allows easy installation and switching between multiple Python versions. (Note: Requires separate setup after installation)
@@ -167,7 +159,7 @@ brew install gradle
 brew install sbt
 
 # A popular replacement for the default macOS Terminal application with many more features (split panes, profiles, triggers, better search, etc.)
-brew install iterm2
+brew install --cask iterm2
 
 #zsh is a powerful shell that is highly customizable and provides a rich set of features.
 brew install zsh
@@ -181,16 +173,31 @@ brew install zsh-autosuggestions
 brew install zsh-completions
 
 #Install browsers
-brew install google-chrome
-brew install firefox
+brew install --cask google-chrome
+brew install --cask firefox
 
 #Install chat tools
-brew install slack
-brew install zoom
+brew install --cask slack
+brew install --cask zoom
+#Claude - AI assistant
+brew install --cask claude
 
 #Install productivity tools
-brew install 1password
+brew install --cask 1password
 brew install 1password-cli
+#draw.io - Diagramming tool
+brew install --cask drawio
+
+#Hardware / Streaming tools
+#Elgato Control Center - Control Elgato devices
+brew install --cask elgato-control-center
+#Elgato Stream Deck - Stream Deck configuration
+brew install --cask elgato-stream-deck
+
+#Fonts
+brew install --cask font-roboto
+brew install --cask font-roboto-mono
+brew install --cask font-roboto-slab
 
 #Remove outdated versions from the cellar.
 brew cleanup

--- a/brew.sh
+++ b/brew.sh
@@ -142,6 +142,8 @@ brew install --cask visual-studio-code
 brew install --cask intellij-idea
 #datagrip
 brew install --cask datagrip
+#Android Studio - Android IDE
+brew install --cask android-studio
 
 #Python Node and Java Version Managers
 #(Python Version Manager): Similar to nvm for Python. Allows easy installation and switching between multiple Python versions. (Note: Requires separate setup after installation)


### PR DESCRIPTION
## Summary
- Add `--cask` flag to all GUI app installs in `brew.sh` for correct reproducibility on fresh machines
- Remove Cursor (no longer used) and non-existent CLI packages (`code-cli`, `cursor-cli`, `intellij-idea-cli`, `datagrip-cli`)
- Add untracked casks: `sourcetree`, `claude`, `drawio`, `elgato-control-center`, `elgato-stream-deck`, `font-roboto`, `font-roboto-mono`, `font-roboto-slab`, `android-studio`
- Add Android SDK environment variables to `.exports` and PATH entries to `.path`
- Add Hardware/Streaming and Fonts sections to `brew.sh` and `CLAUDE.md`
- Update `settings.local.json` with accumulated plugin permissions

## Test plan
- [ ] Run `brew.sh` on a fresh machine or verify `brew install --cask <name>` works for each updated entry
- [ ] Verify `$ANDROID_HOME` resolves correctly after sourcing `.exports`
- [ ] Verify Android SDK tools are on `$PATH` after sourcing `.path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)